### PR TITLE
feat: Support dynamic value coloring

### DIFF
--- a/src/gauge-defaults.service.ts
+++ b/src/gauge-defaults.service.ts
@@ -30,6 +30,11 @@ export interface GaugeOptions {
   label?: (value: number) => string;
 
   /**
+   * Function that returns a string color value for the gauge''s fill (value dial)
+   */
+  color?: (value: number) => string;
+
+  /**
    * Whether to show the value at the center of the gauge
    */
   showValue?: boolean;
@@ -100,6 +105,11 @@ export class GaugeDefaults implements GaugeOptions {
    * Function that returns a string label that will be rendered in the center. This function will be passed the current value
    */
   label: (value: number) => string;
+
+  /**
+   * Function that returns a string color value for the gauge''s fill (value dial)
+   */
+  color: (value: number) => string;
 
   /**
    * Whether to show the value at the center of the gauge

--- a/src/gauge.component.ts
+++ b/src/gauge.component.ts
@@ -47,6 +47,11 @@ export class GaugeComponent implements AfterViewInit, OnChanges, GaugeOptions {
   @Input() label: (value: number) => string;
 
   /**
+   * Function that returns a string color value for the gauge''s fill (value dial)
+   */
+  @Input() color: (value: number) => string;
+
+  /**
    * Whether to show the value at the center of the gauge
    */
   @Input() showValue: boolean;
@@ -108,7 +113,8 @@ export class GaugeComponent implements AfterViewInit, OnChanges, GaugeOptions {
       dialClass: this.dialClass,
       valueDialClass: this.valueDialClass,
       valueClass: this.valueClass,
-      value: this.value
+      value: this.value,
+      color: this.color
     };
 
     Object.keys(this.defaults).forEach(optionKey => {


### PR DESCRIPTION
I added `color` gauge options callback function support for the new (?) svg-gauge version - similarly to how `label` callback is implemented.

This allows to dynamically change gauge colors based on the value (e.g. green, yellow, red for OK, warning, critical).