### PR TITLE
fix: Add type to ModuleWithProviders

### DIFF
--- a/src/gauge.module.ts
+++ b/src/gauge.module.ts
@@ -17,7 +17,7 @@ export function defaultsFactory(userDefaults: GaugeOptions): GaugeDefaults {
   exports: [GaugeComponent]
 })
 export class GaugeModule {
-  static forRoot(userDefaults: GaugeOptions = {}): ModuleWithProviders {
+  static forRoot(userDefaults: GaugeOptions = {}): ModuleWithProviders<GaugeModule> {
     return {
       ngModule: GaugeModule,
       providers: [


### PR DESCRIPTION
Hi!

Great little library. Recently updated an Angular project using this to Angular 10, and got the following in a build pipeline.

```bash
Error: /home/vsts/work/1/s/node_modules/angular-gauge/gauge.module.d.ts(5)
 Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).
```

Seems to be related to this ng10 breaking change https://angular.io/guide/migration-module-with-providers

As far as I can tell the fix is really straightforward.

Happy to make changes if requested.

Thanks